### PR TITLE
Prevent writing to sample sheet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project provides a Streamlit application for managing construction site loc
 
 1. Create a Google Sheet and set its sharing permissions to **Anyone with the link can edit**.
 2. Store the sheet URL in `GSHEET_URL` or add it to `.streamlit/secrets.toml` under `public_gsheet_url`.
+   If no URL is provided the app falls back to a read-only sample sheet.
    You can use the example sheet below:
    ```
    https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
@@ -30,3 +31,4 @@ public_gsheet_url = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuK
 ```
 
 The application will read this secret at runtime.
+When the sample sheet is used, write operations are disabled and you'll see a warning.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,3 @@
-
 import streamlit as st
 import base64
 import pandas as pd
@@ -7,11 +6,13 @@ import db_utils
 # 頁面設定
 st.set_page_config(page_title="禹盛-工地導航系統", layout="wide")
 
+
 # 將 logo.png 轉成 base64 編碼，以內嵌方式顯示
 def image_to_base64(path):
     with open(path, "rb") as image_file:
         encoded = base64.b64encode(image_file.read()).decode()
     return encoded
+
 
 img_base64 = image_to_base64("logo.png")
 
@@ -23,7 +24,7 @@ st.markdown(
         <h2 style='margin: 0;'>禹盛工地導航系統</h2>
     </div>
     """,
-    unsafe_allow_html=True
+    unsafe_allow_html=True,
 )
 
 st.markdown("---")
@@ -41,8 +42,8 @@ df = db_utils.get_all_locations()
 st.subheader("📋 工地清單（依工地名稱首字分組）")
 
 df_display = df.copy()
-df_display['首字'] = df_display['工地名稱'].str[0]
-grouped = df_display.groupby('首字')
+df_display["首字"] = df_display["工地名稱"].str[0]
+grouped = df_display.groupby("首字")
 
 for group_key in sorted(grouped.groups.keys()):
     group = grouped.get_group(group_key)
@@ -55,7 +56,7 @@ for group_key in sorted(grouped.groups.keys()):
                 f"{row['地址']}<br>"
                 f"👷 主任：{row['工地主任']}<br>"
                 f"📞 電話：{row['聯絡電話']}",
-                unsafe_allow_html=True
+                unsafe_allow_html=True,
             )
         with col3:
             confirm_key = f"confirm_{row['id']}"
@@ -64,7 +65,7 @@ for group_key in sorted(grouped.groups.keys()):
                 pwd = st.text_input("刪除密碼", type="password", key=pwd_key)
                 if st.button("確認刪除", key=f"confirm_del_{row['id']}"):
                     if pwd == DELETE_PASSWORD:
-                        db_utils.delete_location(row['id'])
+                        db_utils.delete_location(row["id"])
                         st.experimental_rerun()
                     else:
                         st.error("❌ 密碼錯誤，未進行刪除")
@@ -75,7 +76,9 @@ for group_key in sorted(grouped.groups.keys()):
                     st.session_state[confirm_key] = True
 
         # 🔹 加上淺灰色虛線分隔線
-        st.markdown("<hr style='border-top: 1px dashed lightgray;'>", unsafe_allow_html=True)
+        st.markdown(
+            "<hr style='border-top: 1px dashed lightgray;'>", unsafe_allow_html=True
+        )
 
 # 🔍 搜尋工地
 st.subheader("🔍 查詢工地")
@@ -87,7 +90,7 @@ if search:
         st.markdown(
             f"**{row['工地名稱']}** | {row['地址']} | 👷 {row['工地主任']} | 📞 {row['聯絡電話']} | "
             f"[導航]({row['GoogleMap網址']})",
-            unsafe_allow_html=True
+            unsafe_allow_html=True,
         )
 
 # ➕ 新增工地

--- a/db_utils.py
+++ b/db_utils.py
@@ -3,12 +3,17 @@ import pandas as pd
 import streamlit as st
 from streamlit_gsheets import GSheetsConnection
 
-CSV_PATH = 'site_locations.csv'
-_SHEET_NAME = 'locations'
-# Default sheet URL for convenience when no environment variable or secret is provided
+CSV_PATH = "site_locations.csv"
+_SHEET_NAME = "locations"
+# Default sheet URL for read-only demo when no environment variable or secret is provided
 DEFAULT_SHEET_URL = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0"
 _conn = None
 _sheet_url = None
+
+
+def _writing_enabled() -> bool:
+    """Return True if writing to the sheet is allowed."""
+    return _sheet_url is not None and _sheet_url != DEFAULT_SHEET_URL
 
 
 def _init_connection():
@@ -17,24 +22,20 @@ def _init_connection():
     if _conn is not None:
         return _conn
 
-    _sheet_url = os.environ.get('GSHEET_URL')
+    _sheet_url = os.environ.get("GSHEET_URL")
     if not _sheet_url:
-        _sheet_url = st.secrets.get('public_gsheet_url', None)  # type: ignore
+        _sheet_url = st.secrets.get("public_gsheet_url", None)  # type: ignore
 
     # Fall back to the default sample sheet
     if not _sheet_url:
         _sheet_url = DEFAULT_SHEET_URL
-
-    if not _sheet_url:
-        raise RuntimeError(
-            'Google Sheet URL not configured. Set GSHEET_URL environment variable '
-            'or public_gsheet_url in Streamlit secrets.'
+        st.warning(
+            "⚠️ Using the shared sample sheet. Set the GSHEET_URL environment variable "
+            "or public_gsheet_url in Streamlit secrets to save your own data."
         )
 
-    _conn = st.experimental_connection('gsheets', type=GSheetsConnection)
+    _conn = st.experimental_connection("gsheets", type=GSheetsConnection)
     return _conn
-
-
 
 
 def init_db():
@@ -42,16 +43,19 @@ def init_db():
     conn = _init_connection()
     df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
     if df.empty and os.path.exists(CSV_PATH):
-        df = pd.read_csv(CSV_PATH, dtype={'聯絡電話': str})
-        conn.update(worksheet=_SHEET_NAME, data=df)
+        df = pd.read_csv(CSV_PATH, dtype={"聯絡電話": str})
+        if _writing_enabled():
+            conn.update(worksheet=_SHEET_NAME, data=df)
 
 
 def get_all_locations():
     conn = _init_connection()
     df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
     if df.empty:
-        df = pd.DataFrame(columns=['工地名稱', '地址', 'GoogleMap網址', '工地主任', '聯絡電話'])
-    df.insert(0, 'id', range(2, len(df) + 2))
+        df = pd.DataFrame(
+            columns=["工地名稱", "地址", "GoogleMap網址", "工地主任", "聯絡電話"]
+        )
+    df.insert(0, "id", range(2, len(df) + 2))
     return df
 
 
@@ -59,14 +63,20 @@ def add_location(name, address, url, supervisor, phone):
     conn = _init_connection()
     df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
     new_row = {
-        '工地名稱': name,
-        '地址': address,
-        'GoogleMap網址': url,
-        '工地主任': supervisor,
-        '聯絡電話': phone,
+        "工地名稱": name,
+        "地址": address,
+        "GoogleMap網址": url,
+        "工地主任": supervisor,
+        "聯絡電話": phone,
     }
     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
-    conn.update(worksheet=_SHEET_NAME, data=df)
+    if _writing_enabled():
+        conn.update(worksheet=_SHEET_NAME, data=df)
+    else:
+        st.warning(
+            "Data not saved because the default shared sheet is read-only. "
+            "Set GSHEET_URL or public_gsheet_url to enable editing."
+        )
 
 
 def delete_location(row_id):
@@ -75,4 +85,10 @@ def delete_location(row_id):
     idx = int(row_id) - 2
     if 0 <= idx < len(df):
         df = df.drop(df.index[idx]).reset_index(drop=True)
-        conn.update(worksheet=_SHEET_NAME, data=df)
+        if _writing_enabled():
+            conn.update(worksheet=_SHEET_NAME, data=df)
+        else:
+            st.warning(
+                "Data not deleted because the default shared sheet is read-only. "
+                "Set GSHEET_URL or public_gsheet_url to enable editing."
+            )


### PR DESCRIPTION
## Summary
- warn when falling back to the shared demo sheet
- disable writes when the default sheet is in use
- mention read-only behaviour in the documentation
- format code with black

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f5ee13f08332a4f46e3685b18d77