### PR TITLE
Read password from env/secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ This project provides a Streamlit application for managing construction site loc
    ```
    https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
    ```
-3. Install dependencies:
+3. Set the delete password using the `DELETE_PASSWORD` environment variable or
+   add it to `.streamlit/secrets.toml`.
+4. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-4. Run the Streamlit application:
+5. Run the Streamlit application:
    ```bash
    streamlit run app.py
    ```
@@ -27,6 +29,7 @@ On Streamlit Cloud, create `.streamlit/secrets.toml` with the following content 
 
 ```
 public_gsheet_url = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0"
+DELETE_PASSWORD = "your-password"
 ```
 
 The application will read this secret at runtime.

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import streamlit as st
 import base64
 import pandas as pd
 import db_utils
+import os
 
 # 頁面設定
 st.set_page_config(page_title="禹盛-工地導航系統", layout="wide")
@@ -31,8 +32,10 @@ st.markdown("---")
 # 先初始化資料庫
 db_utils.init_db()
 
-# 刪除密碼
-DELETE_PASSWORD = "27880751"
+# 刪除密碼從環境變數或 Streamlit secrets 讀取
+DELETE_PASSWORD = os.environ.get("DELETE_PASSWORD")
+if not DELETE_PASSWORD:
+    DELETE_PASSWORD = st.secrets.get("DELETE_PASSWORD", "")  # type: ignore
 
 # 讀取資料
 df = db_utils.get_all_locations()


### PR DESCRIPTION
## Summary
- load `DELETE_PASSWORD` from environment variable or Streamlit secrets
- document password secret usage in README

## Testing
- `python -m py_compile app.py db_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f5e433f88332a262a5179840a32e