### PR TITLE
Switch to gspread for Google Sheets access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-# URL of the publicly editable Google Sheet
-GSHEET_URL=https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
+# Google service account JSON (as a single line)
+GOOGLE_SERVICE_ACCOUNT_JSON=
+# Spreadsheet ID to store data
+SPREADSHEET_ID=

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This project provides a Streamlit application for managing construction site loc
 
 ## Setup
 
-1. Create a Google Sheet and set its sharing permissions to **Anyone with the link can edit**.
-2. Store the sheet URL in `GSHEET_URL` or add it to `.streamlit/secrets.toml` under `public_gsheet_url`.
-   You can use the example sheet below:
+1. Create a Google service account and share your spreadsheet with the service account email.
+2. Copy `.env.example` to `.env` and add your service account JSON and spreadsheet ID. The `.env` file is ignored by Git.
+3. Load the environment variables before running the app:
+   ```bash
+   export $(cat .env | xargs)
    ```
-   https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
-   ```
-3. Install dependencies:
+4. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-4. Run the Streamlit application:
+5. Run the Streamlit application:
    ```bash
    streamlit run app.py
    ```
@@ -23,10 +23,12 @@ When the application starts for the first time it populates the Google Sheet wit
 
 ### Streamlit Cloud
 
-On Streamlit Cloud, create `.streamlit/secrets.toml` with the following content so the Sheet URL isn't committed to the repository:
+On Streamlit Cloud, store the credentials and spreadsheet ID as secrets so the service account file is not committed to the repository:
 
 ```
-public_gsheet_url = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0"
+[gcp]
+gcp_service_account = "{...service account JSON...}"
+spreadsheet_id = "<your spreadsheet id>"
 ```
 
 The application will read this secret at runtime.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
-streamlit_gsheets
+gspread
+google-auth


### PR DESCRIPTION
## Summary
- swap deprecated `streamlit_gsheets` for `gspread`
- update db utilities to use service account auth
- update environment variable example and setup docs
- refresh Python package requirements

## Testing
- `python -m py_compile db_utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f5d2bc1883329defb30932c057e2