### PR TITLE
Switch to gspread for Google Sheets access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
-# URL of the publicly editable Google Sheet
-GSHEET_URL=https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
+# Path to your Google service account JSON file
+GOOGLE_SERVICE_ACCOUNT_FILE=service_account.json
+# (Alternatively, put the JSON content directly)
+# GOOGLE_SERVICE_ACCOUNT_JSON=
+# Spreadsheet ID to store data
+SPREADSHEET_ID=

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This project provides a Streamlit application for managing construction site loc
 
 ## Setup
 
-1. Create a Google Sheet and set its sharing permissions to **Anyone with the link can edit**.
-2. Store the sheet URL in `GSHEET_URL` or add it to `.streamlit/secrets.toml` under `public_gsheet_url`.
-   You can use the example sheet below:
+1. Create a Google service account and share your spreadsheet with the service account email.
+2. Copy `.env.example` to `.env` and set `GOOGLE_SERVICE_ACCOUNT_FILE` to the path of your service account key file and `SPREADSHEET_ID` to the ID of your sheet. The `.env` file is ignored by Git. Alternatively you can set `GOOGLE_SERVICE_ACCOUNT_JSON` with the JSON content directly.
+3. Load the environment variables before running the app:
+   ```bash
+   export $(cat .env | xargs)
    ```
-   https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0
-   ```
-3. Install dependencies:
+4. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-4. Run the Streamlit application:
+5. Run the Streamlit application:
    ```bash
    streamlit run app.py
    ```
@@ -23,10 +23,12 @@ When the application starts for the first time it populates the Google Sheet wit
 
 ### Streamlit Cloud
 
-On Streamlit Cloud, create `.streamlit/secrets.toml` with the following content so the Sheet URL isn't committed to the repository:
+On Streamlit Cloud, store the JSON credentials and spreadsheet ID as secrets so the service account file is not committed to the repository:
 
 ```
-public_gsheet_url = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0"
+[gcp]
+gcp_service_account = "{...service account JSON...}"
+spreadsheet_id = "<your spreadsheet id>"
 ```
 
 The application will read this secret at runtime.

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,78 +1,87 @@
 import os
+import json
 import pandas as pd
-import streamlit as st
-from streamlit_gsheets import GSheetsConnection
+import gspread
+from google.oauth2.service_account import Credentials
 
 CSV_PATH = 'site_locations.csv'
 _SHEET_NAME = 'locations'
-# Default sheet URL for convenience when no environment variable or secret is provided
-DEFAULT_SHEET_URL = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0"
-_conn = None
-_sheet_url = None
+_sheet = None
 
 
-def _init_connection():
-    """Initialize the Google Sheets connection."""
-    global _conn, _sheet_url
-    if _conn is not None:
-        return _conn
+def _init_sheet():
+    """Initialize and cache the Google Sheet instance."""
+    global _sheet
+    if _sheet is not None:
+        return _sheet
 
-    _sheet_url = os.environ.get('GSHEET_URL')
-    if not _sheet_url:
-        _sheet_url = st.secrets.get('public_gsheet_url', None)  # type: ignore
+    creds_json = os.environ.get('GOOGLE_SERVICE_ACCOUNT_JSON')
+    creds_file = os.environ.get('GOOGLE_SERVICE_ACCOUNT_FILE')
+    spreadsheet_id = os.environ.get('SPREADSHEET_ID')
 
-    # Fall back to the default sample sheet
-    if not _sheet_url:
-        _sheet_url = DEFAULT_SHEET_URL
+    if creds_file and not creds_json:
+        try:
+            with open(creds_file, 'r') as f:
+                creds_json = f.read()
+        except OSError:
+            pass
 
-    if not _sheet_url:
+    if not creds_json or not spreadsheet_id:
+        try:
+            import streamlit as st
+            creds_json = creds_json or st.secrets.get('gcp_service_account')  # type: ignore
+            spreadsheet_id = spreadsheet_id or st.secrets.get('spreadsheet_id')  # type: ignore
+        except Exception:
+            pass
+
+    if not creds_json or not spreadsheet_id:
         raise RuntimeError(
-            'Google Sheet URL not configured. Set GSHEET_URL environment variable '
-            'or public_gsheet_url in Streamlit secrets.'
+            'Google Sheets credentials not configured. Set GOOGLE_SERVICE_ACCOUNT_FILE '
+            'or GOOGLE_SERVICE_ACCOUNT_JSON and SPREADSHEET_ID, or configure them in Streamlit secrets.'
         )
 
-    _conn = st.experimental_connection('gsheets', type=GSheetsConnection)
-    return _conn
+    creds_info = json.loads(creds_json)
+    creds = Credentials.from_service_account_info(
+        creds_info,
+        scopes=['https://www.googleapis.com/auth/spreadsheets'],
+    )
+    client = gspread.authorize(creds)
+    spreadsheet = client.open_by_key(spreadsheet_id)
+    try:
+        _sheet = spreadsheet.worksheet(_SHEET_NAME)
+    except gspread.exceptions.WorksheetNotFound:
+        _sheet = spreadsheet.sheet1
+        _sheet.update_title(_SHEET_NAME)
+    return _sheet
 
 
 
 
 def init_db():
     """Populate the sheet with initial data if it's empty."""
-    conn = _init_connection()
-    df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
-    if df.empty and os.path.exists(CSV_PATH):
+    sheet = _init_sheet()
+    if len(sheet.get_all_values()) == 0 and os.path.exists(CSV_PATH):
         df = pd.read_csv(CSV_PATH, dtype={'聯絡電話': str})
-        conn.update(worksheet=_SHEET_NAME, data=df)
+        rows = [df.columns.tolist()] + df.values.tolist()
+        sheet.append_rows(rows)
 
 
 def get_all_locations():
-    conn = _init_connection()
-    df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
-    if df.empty:
-        df = pd.DataFrame(columns=['工地名稱', '地址', 'GoogleMap網址', '工地主任', '聯絡電話'])
-    df.insert(0, 'id', range(2, len(df) + 2))
+    sheet = _init_sheet()
+    rows = sheet.get_all_values()
+    if not rows:
+        return pd.DataFrame(columns=['id', '工地名稱', '地址', 'GoogleMap網址', '工地主任', '聯絡電話'])
+    header, *data = rows
+    df = pd.DataFrame(data, columns=header)
+    df.insert(0, 'id', range(2, len(data) + 2))
     return df
 
 
 def add_location(name, address, url, supervisor, phone):
-    conn = _init_connection()
-    df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
-    new_row = {
-        '工地名稱': name,
-        '地址': address,
-        'GoogleMap網址': url,
-        '工地主任': supervisor,
-        '聯絡電話': phone,
-    }
-    df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
-    conn.update(worksheet=_SHEET_NAME, data=df)
+    sheet = _init_sheet()
+    sheet.append_row([name, address, url, supervisor, phone])
 
 
 def delete_location(row_id):
-    conn = _init_connection()
-    df = conn.read(spreadsheet=_sheet_url, worksheet=_SHEET_NAME, ttl=0)
-    idx = int(row_id) - 2
-    if 0 <= idx < len(df):
-        df = df.drop(df.index[idx]).reset_index(drop=True)
-        conn.update(worksheet=_SHEET_NAME, data=df)
+    sheet = _init_sheet()
+    sheet.delete_rows(int(row_id))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
-streamlit_gsheets
+gspread
+google-auth


### PR DESCRIPTION
## Summary
- swap deprecated `streamlit_gsheets` for `gspread`
- update db utilities to use service account auth
- update environment variable example and setup docs
- refresh Python package requirements
- allow loading service account credentials from a file path

## Testing
- `python -m py_compile db_utils.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6858f5d2bc1883329defb30932c057e2