### PR TITLE
Switch to gspread for Google Sheets

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,2 +1,3 @@
-[connections.gsheets]
-spreadsheet = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0#gid=0"
+[gcp]
+# gcp_service_account = "{...}"
+spreadsheet_id = "1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE"

--- a/README.md
+++ b/README.md
@@ -5,30 +5,19 @@ This project provides a Streamlit application for managing construction site loc
 ## Setup
 
 1. Create a Google service account and share your spreadsheet with the service account email.
-2. Copy `.env.example` to `.env` and add your service account JSON and spreadsheet ID. The `.env` file is ignored by Git.
-3. Load the environment variables before running the app:
-   ```bash
-   export $(cat .env | xargs)
+2. Create a `secrets.toml` (or `.streamlit/secrets.toml` on Streamlit Cloud) containing your service account JSON and spreadsheet ID:
+   ```toml
+   [gcp]
+   gcp_service_account = "{...service account JSON...}"
+   spreadsheet_id = "<your spreadsheet id>"
    ```
-4. Install dependencies:
+3. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-5. Run the Streamlit application:
+4. Run the Streamlit application:
    ```bash
    streamlit run app.py
    ```
 
 When the application starts for the first time it populates the Google Sheet with data from `site_locations.csv` if the sheet is empty.
-
-### Streamlit Cloud
-
-On Streamlit Cloud, store the credentials and spreadsheet ID as secrets so the service account file is not committed to the repository:
-
-```
-[gcp]
-gcp_service_account = "{...service account JSON...}"
-spreadsheet_id = "<your spreadsheet id>"
-```
-
-The application will read this secret at runtime.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 import streamlit as st
 import base64
-from streamlit_gsheets import GSheetsConnection
+import json
+import pandas as pd
+import gspread
+from google.oauth2.service_account import Credentials
 
 # 頁面設定
 st.set_page_config(page_title="禹盛-工地導航系統", layout="wide")
@@ -23,36 +26,51 @@ st.markdown(
 
 st.markdown("---")
 
-# 直接使用「發布到網路」後的 CSV 連結
-CSV_URL = (
-    "https://docs.google.com/spreadsheets/d/e/"
-    "2PACX-1vR0AmC5c3vXNRglsmynyaXb5T4_3Qwiw1L2sk6Gb8zawNUGECxJ3CZogH58Xl5bDMwpYHzW4_35T5Uk/"
-    "pub?gid=0&single=true&output=csv"
-)
+# 讀取 Google Sheet
+service_account_info = json.loads(st.secrets["gcp"]["gcp_service_account"])
+spreadsheet_id = st.secrets["gcp"]["spreadsheet_id"]
 
-# 建立連線並讀取資料
-conn = st.connection("gsheets", type=GSheetsConnection)
-df = conn.read(
-    spreadsheet=CSV_URL,
-    ttl="10m"
+credentials = Credentials.from_service_account_info(
+    service_account_info,
+    scopes=[
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ],
 )
+gc = gspread.authorize(credentials)
+worksheet = gc.open_by_key(spreadsheet_id).sheet1
+
+rows = worksheet.get_all_records()
+df = pd.DataFrame(rows, dtype=str)
 
 # 顯示工地清單
-st.subheader("📋 工地清單")
+st.subheader("📋 工地清單（依工地名稱首字分組）")
+COLUMNS = ["工地名稱", "地址", "GoogleMap網址", "工地主任", "聯絡電話"]
+if df.empty:
+    df = pd.DataFrame(columns=COLUMNS)
+
 df_display = df.copy()
-df_display['首字'] = df_display['工地名稱'].str[0]
-for key, group in df_display.groupby('首字'):
+df_display["首字"] = df_display["工地名稱"].str[0]
+for key in sorted(df_display["首字"].unique()):
+    group = df_display[df_display["首字"] == key]
     st.markdown(f"### {key}")
-    for row in group.itertuples(index=False):
+    for idx, row in group.iterrows():
         col1, _, col3 = st.columns([6, 1, 1])
         with col1:
             st.markdown(
-                f"**{row.工地名稱}**  |  {row.地址}<br>"
-                f"[📍 導航]({row.GoogleMap網址})<br>"
-                f"👷 {row.工地主任}  📞 {row.聯絡電話}",
+                f"**{row['工地名稱']}**  |  {row['地址']}<br>"
+                f"[📍 導航]({row['GoogleMap網址']})<br>"
+                f"👷 {row['工地主任']}  📞 {row['聯絡電話']}",
                 unsafe_allow_html=True,
             )
-        st.markdown("<hr style='border-top:1px dashed lightgray;'>", unsafe_allow_html=True)
+        with col3:
+            if st.button("刪除", key=f"del_{idx}"):
+                worksheet.delete_rows(idx + 2)
+                st.experimental_rerun()
+        st.markdown(
+            "<hr style='border-top:1px dashed lightgray;'>",
+            unsafe_allow_html=True,
+        )
 
 # 搜尋功能
 st.subheader("🔍 查詢工地")
@@ -61,3 +79,20 @@ if search:
     filtered = df[df.apply(lambda r: search in r.to_string(), axis=1)]
     st.write(f"🔎 查詢結果：{len(filtered)} 筆")
     st.dataframe(filtered)
+
+# ➕ 新增工地
+with st.expander("➕ 新增工地資料"):
+    with st.form("add_form"):
+        name = st.text_input("工地名稱")
+        address = st.text_input("地址")
+        url = st.text_input("Google Map 導航連結")
+        supervisor = st.text_input("工地主任姓名")
+        phone = st.text_input("聯絡電話")
+        submit = st.form_submit_button("新增")
+        if submit:
+            if name and url:
+                worksheet.append_row([name, address, url, supervisor, phone])
+                st.success("✅ 已新增工地")
+                st.experimental_rerun()
+            else:
+                st.error("❌ 請填寫工地名稱與 Google Map 連結")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ streamlit
 pandas
 gspread
 google-auth
-st-gsheets-connection

--- a/secrets.toml
+++ b/secrets.toml
@@ -1,2 +1,4 @@
-[connections.gsheets]
-spreadsheet = "https://docs.google.com/spreadsheets/d/1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE/edit?gid=0#gid=0"
+[gcp]
+# 將你的 Service Account JSON 內容放在這裡
+# gcp_service_account = "{...}"
+spreadsheet_id = "1VV2AXV7-ZudWApvRiuKW8gcehXOM1CaPXGyHyFvDPQE"


### PR DESCRIPTION
## Summary
- use gspread to read and write Google Sheets
- update Streamlit app with add/delete support
- drop st-gsheets-connection dependency
- document new secret format

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68592fe6133c8332ba15bde99434c8f2